### PR TITLE
docs: corrected NX serve command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,7 @@ Fill in the blanks with the appropriate information. Ask the team directly for d
 The simplest way to run both frontend and backend in a single terminal is:
 
 ```sh
-nx run-many --parallel --target=serve --projects=frontend,backend
-```
+nx run-many --parallel --target=serve --all
 
 But you can run whatever `nx ...` command you want!
 


### PR DESCRIPTION
### 📝 Description

Changed nx run-many --parallel --target=serve --projects=frontend,backend to nx run-many --parallel --target=serve --all to fix an issue with NX detecting 0 projects to serve.

### ✔️ Verification

Ran nx run-many --parallel --target=serve --all, which successfully detected frontend and backend
![image](https://user-images.githubusercontent.com/73801512/221712322-aa6bdf89-5459-4072-9ad7-f2286c593336.png)