### PR TITLE
Feature/aws geocoding

### DIFF
--- a/apps/frontend/src/app/SearchTherapists.tsx
+++ b/apps/frontend/src/app/SearchTherapists.tsx
@@ -108,22 +108,24 @@ export const SearchTherapists: React.FC = () => {
   }
 
   console.log('data', data);
-  const therapists = data?.filter(
-    (therapist) =>
-      therapist.geocode == null ||
-      coords == null ||
-      (searchQuery.maxDistance ?? Number.MAX_VALUE) >=
-        dist(
-          therapist.geocode?.lat,
-          therapist.geocode?.long,
-          coords?.latitude,
-          coords?.longitude
-        )
-  )
+  // const therapists = data?.filter(
+  //   (therapist) =>
+  //     therapist.geocode == null ||
+  //     coords == null ||
+  //     (searchQuery.maxDistance ?? Number.MAX_VALUE) >=
+  //       dist(
+  //         therapist.geocode?.lat,
+  //         therapist.geocode?.long,
+  //         coords?.latitude,
+  //         coords?.longitude
+  //       )
+  // )
 
-  if (searchQuery.searchString.length === 0) {
-    therapists?.sort((a, b) => comparableDistance(a) - comparableDistance(b));
-  }
+  const therapists = data;
+
+  // if (searchQuery.searchString.length === 0) {
+  //   therapists?.sort((a, b) => comparableDistance(a) - comparableDistance(b));
+  // }
 
   const [numTherapistsToRender, setNumTherapistsToRender] = useState(10);
 

--- a/apps/frontend/src/app/SearchTherapists.tsx
+++ b/apps/frontend/src/app/SearchTherapists.tsx
@@ -66,7 +66,7 @@ export const SearchTherapists: React.FC = () => {
   const [searchQuery, setSearchQuery] = useState<SearchTherapistsQuery>({
     searchString: '',
     languages: [],
-    maxDistance: 1000,
+    maxDistance: 100,
   });
 
   const [searchResult, setSearchResult] = useState<
@@ -108,6 +108,13 @@ export const SearchTherapists: React.FC = () => {
   }
 
   console.log('data', data);
+  const therapists = data?.filter((therapist) => {
+    return dist(therapist.geocode.lat, 
+      therapist.geocode.long,
+      coords?.latitude, 
+      coords?.longitude) < searchQuery.maxDistance;
+  })
+
   // const therapists = data?.filter(
   //   (therapist) =>
   //     therapist.geocode == null ||
@@ -121,11 +128,9 @@ export const SearchTherapists: React.FC = () => {
   //       )
   // )
 
-  const therapists = data;
-
-  // if (searchQuery.searchString.length === 0) {
-  //   therapists?.sort((a, b) => comparableDistance(a) - comparableDistance(b));
-  // }
+  if (searchQuery.searchString.length === 0) {
+    therapists?.sort((a, b) => comparableDistance(a) - comparableDistance(b));
+  }
 
   const [numTherapistsToRender, setNumTherapistsToRender] = useState(10);
 
@@ -235,7 +240,9 @@ export const SearchTherapists: React.FC = () => {
                           <Text>{therapist.email}</Text>
                         </Box>
                       </WrapItem>
-                      <WrapItem>
+                      {
+                        therapist.website && (
+                          <WrapItem>
                         <Box>
                           <Box
                             color="gray.500"
@@ -253,6 +260,8 @@ export const SearchTherapists: React.FC = () => {
                           </Text>
                         </Box>
                       </WrapItem>
+                        )
+                      }
                       <WrapItem>
                         <Box>
                           <Box
@@ -313,19 +322,17 @@ export const SearchTherapists: React.FC = () => {
       )}
 
       {isLoading && (
-        <>
           <Stack spacing={5} marginTop="48px">
             <Skeleton height="240px" />
             <Skeleton height="240px" />
             <Skeleton height="240px" />
           </Stack>
-        </>
       )}
     </div>
   );
 };
 
-function dist(lat1: number, lon1: number, lat2: number, lon2: number) {
+export function dist(lat1: number, lon1: number, lat2: number, lon2: number) {
   const R = 6371e3; // metres
   const φ1 = (lat1 * Math.PI) / 180; // φ, λ in radians
   const φ2 = (lat2 * Math.PI) / 180;

--- a/apps/frontend/src/app/SearchTherapistsFilter.tsx
+++ b/apps/frontend/src/app/SearchTherapistsFilter.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { 
     Accordion, 
     AccordionButton, 
@@ -10,8 +10,15 @@ import {
     VStack,
     Checkbox,
     CheckboxGroup, 
-    Heading 
+    Heading,
+    Slider,
+    SliderMark,
+    SliderFilledTrack,
+    SliderThumb,
+    SliderTrack,
+    Tooltip
 } from '@chakra-ui/react';
+
 import { SearchTherapistsQuery } from './actionsController';
 
 interface SearchTherapistsFilterProps { 
@@ -21,12 +28,15 @@ interface SearchTherapistsFilterProps {
 }
 
 const SearchTherapistsFilter: React.FC<SearchTherapistsFilterProps> = ({ searchQuery, setSearchQuery, availableLanguages }) => {
+    const [distance, setDistance] = useState(searchQuery.maxDistance);
+    const [showTooltip, setShowTooltip] = useState(false);
+
     return (
         <Accordion allowToggle mt={2}>
             <AccordionItem borderTop={0}>
                 <h2>
                     <AccordionButton>
-                        <Box as='span' flex='1' textAlign='left'>Search Filters</Box>
+                        <Box as='span' flex='1' textAlign='left'>Advanced Filters</Box>
                         <AccordionIcon />
                     </AccordionButton>
                 </h2>
@@ -35,7 +45,7 @@ const SearchTherapistsFilter: React.FC<SearchTherapistsFilterProps> = ({ searchQ
                         <Box>
                             <Heading size='sm' mb={2}>Languages</Heading>
                             <HStack spacing={3}>
-                                <CheckboxGroup colorScheme='green' onChange={(selectedLanguages) => {
+                                <CheckboxGroup colorScheme='green' onChange={(selectedLanguages: (string | number)[]) => {
                                     setSearchQuery({...searchQuery, languages: selectedLanguages})
                                 }}>
                                     {availableLanguages.map((language) => {
@@ -45,6 +55,41 @@ const SearchTherapistsFilter: React.FC<SearchTherapistsFilterProps> = ({ searchQ
                             </HStack>
                         </Box>
                     </VStack>
+                    <Box>
+                        <Heading size='sm' mt={2} mb={2}>Maximum Distance</Heading>
+                            <Slider
+                                id='distance-slider'
+                                defaultValue={distance}
+                                min={0}
+                                max={200}
+                                colorScheme='teal'
+                                onChange={(distance: number) => setDistance(distance)}
+                                onMouseEnter={() => setShowTooltip(true)}
+                                onMouseLeave={() => setShowTooltip(false)}
+                                onChangeEnd={(distance: number) => setSearchQuery({...searchQuery, maxDistance: distance})}>
+                                    <SliderMark value={50} mt='1' ml='-2.5' fontSize='sm'>
+                                        50 Miles
+                                    </SliderMark>
+                                    <SliderMark value={100} mt='1' ml='-2.5' fontSize='sm'>
+                                        100 Miles
+                                    </SliderMark>
+                                    <SliderMark value={150} mt='1' ml='-2.5' fontSize='sm'>
+                                        150 Miles
+                                    </SliderMark>
+                                    <SliderTrack>
+                                        <SliderFilledTrack />
+                                    </SliderTrack>
+                                    <Tooltip
+                                        hasArrow
+                                        bg='teal.500'
+                                        color='white'
+                                        placement='top'
+                                        isOpen={showTooltip}
+                                        label={`${distance} miles`}>
+                                        <SliderThumb />
+                                    </Tooltip>
+                            </Slider>
+                    </Box>
                 </AccordionPanel>
             </AccordionItem>
         </Accordion>

--- a/apps/frontend/src/app/actionsController.ts
+++ b/apps/frontend/src/app/actionsController.ts
@@ -6,6 +6,7 @@ import longTimePartnerImage from '../assets/Badge_Heart.png';
 import frequentPartner from '../assets/Badge_Partner.png';
 import raw from './raw.json';
 import { createApiClient } from '@monarch/common';
+import { dist } from './SearchTherapists';
 
 const baseUrl = import.meta.env.VITE_API_BASE_URL;
 
@@ -66,7 +67,7 @@ export interface ActionsController {
 export interface SearchTherapistsQuery {
   searchString: string;
   languages: (string | number)[];
-  maxDistance?: number;
+  maxDistance: number;
 }
 
 const LB_CORP_MONTHLY_DONOR: Badge = {

--- a/apps/frontend/src/app/actionsController.ts
+++ b/apps/frontend/src/app/actionsController.ts
@@ -221,6 +221,10 @@ async function fetchAllPractitioners(useFake = false): Promise<Therapist[]> {
       website: d.website,
       badges: [],
       languages: d.languagesList,
+      geocode: {
+        lat: d.geocode.lat,
+        long: d.geocode.long,
+      }
     }));
     return therapists;
   }

--- a/apps/frontend/src/app/therapist.ts
+++ b/apps/frontend/src/app/therapist.ts
@@ -10,7 +10,7 @@ export interface Therapist {
   phone: string
   profilePictureUrl: string
 
-  geocode?: {
+  geocode: {
     lat: number
     long: number
     canonicalAddress: string

--- a/apps/frontend/src/app/therapist.ts
+++ b/apps/frontend/src/app/therapist.ts
@@ -13,7 +13,6 @@ export interface Therapist {
   geocode: {
     lat: number
     long: number
-    canonicalAddress: string
   }
 
   minimumAgeServed: number; // nat

--- a/libs/common/src/lib/dto/Practitioner.ts
+++ b/libs/common/src/lib/dto/Practitioner.ts
@@ -11,6 +11,10 @@ export const Practitioner = z.object({
   email: z.string().email(),
   fullName: z.string(),
   languagesList: z.array(z.string()),
+  geocode: z.object({
+    lat: z.number(),
+    long: z.number(),
+  })
 })
 
 export type Practitioner = z.infer<typeof Practitioner>


### PR DESCRIPTION
### ℹ️ Issue

Closes #12 

### 📝 Description

- Modified SearchTherapistsFilter component to include an option for filtering therapists by distance.
- Ran a script to update DynamoDB records with AWS Location Service place index geoencoded latitudes/longitudes based on supplied business locations. All records now include an attribute called geocode of the form { lat: {N: value}, long: {N: value} }. 
- Minor UI change (don't display website if not given by the therapist)
- Modified Zodios schema to include the new geocode property and made geocode property mandatory in the Therapist data definition.

### ✔️ Verification

- Tested that different values of the maximum distance slider updated the displayed records appropriately.
- Combined distance and language filters to ensure that the behavior of the combined filters also behaves as expected.

![image](https://user-images.githubusercontent.com/73801512/232328290-25fb422f-2fcb-4add-a6eb-d615bdba5252.png)

### 🏕️ (Optional) Future Work / Notes

Potential bug: Whenever I run nx run-many --parallel --target=serve --all, localhost 4200 fails to load the data, but when I refresh, everything works as expected.
![image](https://user-images.githubusercontent.com/73801512/232328462-25e61458-c342-46cf-b8af-f26d1c5618fc.png)


